### PR TITLE
(chore) File with bad markup

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,2 @@
 remark:
   enabled: true
-  config_file: .remarkrc

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,3 @@
 remark:
   enabled: true
+  config_file: .remarkrc

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,3 @@
 remark:
-  version: 6.0.2
+  enabled: true
+  config_file: .remarkrc

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+remark:
+  version: 6.0.2

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "remark-lint",
+    "remark-cli",
+    "remark-preset-lint-markdown-style-guide",
+    ["remark-list-item-spacing", false]
+  ]
+}

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,9 +1,5 @@
 {
   "plugins": [
-    "preset-lint-markdown-style-guide",
-    ["lint-maximum-line-length", false],
-    ["lint-list-item-spacing", false],
-    ["lint-unordered-list-marker-style", false],
-    ["lint-heading-increment", true]
+    "preset-lint-markdown-style-guide"
   ]
 }

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,8 +1,10 @@
 {
   "plugins": [
-    "remark-lint",
-    "remark-cli",
-    "remark-preset-lint-markdown-style-guide",
-    ["remark-list-item-spacing", false]
+    "preset-lint-markdown-style-guide",
+    ["lint-maximum-line-length", false],
+    ["lint-list-item-spacing", false],
+    ["lint-unordered-list-marker-style", false],
+    ["lint-heading-increment", true],
+    ["remark-lint-no-trailing-spaces", true]
   ]
 }

--- a/.remarkrc
+++ b/.remarkrc
@@ -4,7 +4,6 @@
     ["lint-maximum-line-length", false],
     ["lint-list-item-spacing", false],
     ["lint-unordered-list-marker-style", false],
-    ["lint-heading-increment", true],
-    ["remark-lint-no-trailing-spaces", true]
+    ["lint-heading-increment", true]
   ]
 }

--- a/bad.md
+++ b/bad.md
@@ -1,4 +1,4 @@
-Clearly a bad file with linting offenses!
+Clearly a bad file with linting offenses!   
 
 
 <html>look at all this inline html!</html>

--- a/bad.md
+++ b/bad.md
@@ -1,7 +1,0 @@
-Clearly a bad file with linting offenses!   
-
-
-<html>look at all this inline html!</html>
-
-- bad
-- list

--- a/bad.md
+++ b/bad.md
@@ -1,0 +1,7 @@
+Clearly a bad file with linting offenses!
+
+
+<html>look at all this inline html!</html>
+
+- bad
+- list

--- a/contributing.md
+++ b/contributing.md
@@ -1,5 +1,8 @@
 # Contributing to the Playbook
 
+
+
+
 ## What you will need
 
 1. A GitHub account

--- a/file-with-bad-markup.md
+++ b/file-with-bad-markup.md
@@ -1,0 +1,21 @@
+# Top level heading
+
+
+## Break all the rules
+
+# Oh look, another top level heading
+
+## Break all the rules
+
+* Here's an asterisk list!
+* Oh no, will the Hound catch it?
+* To be fair, it's both the Hound and remark that have obscure, minimalistic documentation
+- Why are rules anyway?
+
+### Let's make an ordered list!
+
+1. An item
+2. Another item
+2. Gotcha
+
+

--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
     "prismjs": "^1.9.0",
     "remark-lint": "^6.0.4",
     "remark-cli": "^6.0.1",
-    "remark-lint-no-trailing-spaces": "^2.0.0",
     "remark-preset-lint-markdown-style-guide": "^2.1.2"
   },
   "devDependencies": {
     "remark-cli": "^6.0.1",
-    "remark-lint-no-trailing-spaces": "^2.0.0",
     "remark-preset-lint-markdown-style-guide": "^2.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,22 @@
   "version": "1.0.0",
   "description": "dxw Playbook",
   "scripts": {
-    "start": "docsify serve ."
+    "start": "docsify serve .",
+    "lint-md": "remark ."
   },
   "dependencies": {
     "docsify": "^4.5.5",
     "docsify-cli": "^4.1.12",
     "marked": "^0.3.7",
-    "prismjs": "^1.9.0"
+    "prismjs": "^1.9.0",
+    "remark-lint": "^6.0.4",
+    "remark-cli": "^6.0.1",
+    "remark-lint-no-trailing-spaces": "^2.0.0",
+    "remark-preset-lint-markdown-style-guide": "^2.1.2"
+  },
+  "devDependencies": {
+    "remark-cli": "^6.0.1",
+    "remark-lint-no-trailing-spaces": "^2.0.0",
+    "remark-preset-lint-markdown-style-guide": "^2.1.2"
   }
 }


### PR DESCRIPTION
According to https://github.com/remarkjs/remark-lint/tree/master/packages/remark-preset-lint-markdown-style-guide, the preset should catch a lot of the markup in this file by default.