### PR TITLE
(chore) File with bad markup

### DIFF
--- a/file-with-bad-markup.md
+++ b/file-with-bad-markup.md
@@ -1,0 +1,21 @@
+# Top level heading
+
+
+## Break all the rules
+
+# Oh look, another top level heading
+
+## Break all the rules
+
+* Here's an asterisk list!
+* Oh no, will the Hound catch it?
+* To be fair, it's both the Hound and remark that have obscure, minimalistic documentation
+- Why are rules anyway?
+
+### Let's make an ordered list!
+
+1. An item
+2. Another item
+2. Gotcha
+
+


### PR DESCRIPTION
According to https://github.com/remarkjs/remark-lint/tree/master/packages/remark-preset-lint-markdown-style-guide, the preset should catch a lot of the markup in this file by default.